### PR TITLE
[no marge] out_stackdriver: support stackdriver trace span (#4223)

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1280,6 +1280,7 @@ static int pack_json_payload(int insert_id_extracted,
         ctx->labels_key,
         ctx->severity_key,
         ctx->trace_key,
+        ctx->span_id_key,
         ctx->log_name_key,
         stream
         /* more special fields are required to be added, but, if this grows with more
@@ -1457,6 +1458,10 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
     flb_sds_t trace;
     char stackdriver_trace[PATH_MAX];
     const char *new_trace;
+
+    /* Parameters for spanID */
+    int span_id_extracted = FLB_FALSE;
+    flb_sds_t span_id;
 
     /* Parameters for log name */
     int log_name_extracted = FLB_FALSE;
@@ -1892,6 +1897,7 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
          *  "jsonPayload": {...},
          *  "timestamp": "...",
          *  "trace": "..."
+         *  "spanId": "..."
          * }
          */
         entry_size = 3;
@@ -1909,6 +1915,14 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
         if (ctx->trace_key
             && get_string(&trace, obj, ctx->trace_key) == 0) {
             trace_extracted = FLB_TRUE;
+            entry_size += 1;
+        }
+
+        /* Extract spanID */
+        span_id_extracted = FLB_FALSE;
+        if (ctx->span_id_key
+            && get_string(&span_id, obj, ctx->span_id_key) == 0) {
+            span_id_extracted = FLB_TRUE;
             entry_size += 1;
         }
 
@@ -2016,6 +2030,16 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
             msgpack_pack_str(&mp_pck, len);
             msgpack_pack_str_body(&mp_pck, new_trace, len);
             flb_sds_destroy(trace);
+        }
+
+        /* Add spanID into the log entry */
+        if (span_id_extracted == FLB_TRUE) {
+            msgpack_pack_str(&mp_pck, 7);
+            msgpack_pack_str_body(&mp_pck, "span_id", 7);
+            len = flb_sds_len(span_id);
+            msgpack_pack_str(&mp_pck, len);
+            msgpack_pack_str_body(&mp_pck, span_id, len);
+            flb_sds_destroy(span_id);
         }
 
         /* Add insertId field into the log entry */
@@ -2392,6 +2416,11 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_STR, "trace_key", DEFAULT_TRACE_KEY,
       0, FLB_TRUE, offsetof(struct flb_stackdriver, trace_key),
       "Set the trace key"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "span_id_key", DEFAULT_SPAN_ID_KEY,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, span_id_key),
+      "Set the span id key"
     },
     {
       FLB_CONFIG_MAP_STR, "log_name_key", DEFAULT_LOG_NAME_KEY,

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -53,6 +53,7 @@
 #define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
 #define DEFAULT_SEVERITY_KEY "logging.googleapis.com/severity"
 #define DEFAULT_TRACE_KEY "logging.googleapis.com/trace"
+#define DEFAULT_SPAN_ID_KEY "logging.googleapis.com/spanId"
 #define DEFAULT_LOG_NAME_KEY "logging.googleapis.com/logName"
 #define DEFAULT_INSERT_ID_KEY "logging.googleapis.com/insertId"
 #define SOURCELOCATION_FIELD_IN_JSON "logging.googleapis.com/sourceLocation"
@@ -147,6 +148,7 @@ struct flb_stackdriver {
     flb_sds_t resource;
     flb_sds_t severity_key;
     flb_sds_t trace_key;
+    flb_sds_t span_id_key;
     flb_sds_t log_name_key;
     flb_sds_t http_request_key;
     int http_request_key_size;

--- a/tests/runtime/data/stackdriver/stackdriver_test_trace.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_trace.h
@@ -1,6 +1,6 @@
 #define TRACE_COMMON_CASE	"[" \
 	"1591111124," \
 	"{"	\
-        "\"trace\": \"test-trace-id-xyz\"" \
+        "\"trace\": \"test-trace-id-xyz\"," \
+        "\"spanId\": \"test-span-id-abc\""  \
 	"}]"
-	


### PR DESCRIPTION
logentry will be able to bind to span in the Google Cloud Web UI.

Specifically Cloud Trace (Stackdriver),
the `logging.googleapis.com/traceId` field is
moved to the top of the log entry and renames it to `traceId`.

Signed-off-by: 0Delta <0deltast@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
